### PR TITLE
set the path because it's known

### DIFF
--- a/Lib/Neon.Roslyn.Xunit/AdditionalSourceText.cs
+++ b/Lib/Neon.Roslyn.Xunit/AdditionalSourceText.cs
@@ -73,7 +73,7 @@ namespace Neon.Roslyn.Xunit
         /// <returns></returns>
         public static AdditionalSourceText FromFile(string path)
         {
-            return new AdditionalSourceText(File.ReadAllText(path));
+            return new AdditionalSourceText(File.ReadAllText(path), path: path);
         }
 
         /// <summary>


### PR DESCRIPTION
It is useful to set the path to something realistic because many of the examples for `IIncrementalGenerator` using the `AdditionalTextsProvider` are filtering files by the extension.