### PR TITLE
Fix Issue #94 MissingMethodException

### DIFF
--- a/Lib/Neon.SSH/LinuxSshProxy.cs
+++ b/Lib/Neon.SSH/LinuxSshProxy.cs
@@ -2423,7 +2423,7 @@ echo $? > {cmdFolder}/exit
                 {
                     Command     = command,
                     BashCommand = bashCommand,
-                    ExitCode    = cmdResult.ExitStatus,
+                    ExitCode    = cmdResult.ExitStatus ?? 0,
                     OutputText  = cmdResult.Result,
                     ErrorText   = cmdResult.Error
                 };

--- a/Lib/Neon.SSH/Neon.SSH.csproj
+++ b/Lib/Neon.SSH/Neon.SSH.csproj
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SSH.NET" Version="2020.0.2" />
+        <PackageReference Include="SSH.NET" Version="2024.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Lib/Neon.XenServer/Neon.XenServer.csproj
+++ b/Lib/Neon.XenServer/Neon.XenServer.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SSH.NET" Version="2020.0.2" />
+        <PackageReference Include="SSH.NET" Version="2024.2.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fix #94 
Update SSH.NET NuGet dependency to current 2024.2.0 which avoids missing method exception. 

There are no code changes to accept this update beyond the following:
Convert SshCommand.ExitStatus to 0 on a null result. This is equivalent to the result of the previous SSH.NET implementation.


I'm open to updating (and/or consolidating) other NuGet Dependencies here but limited the update because of my relative lack of familiarity with how these dependencies might effect the project as a whole.